### PR TITLE
showcase in sync with 6.1.1 related dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.primefaces.extensions</groupId>
         <artifactId>master-pom</artifactId>
-        <version>6.1.0</version>
+        <version>6.1.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Currently the showcase is referring to 6.1.0 jars, so any development on core lib won't be reflected in the showcase.

After this pull, the project should run just fine.

---

![image](https://cloud.githubusercontent.com/assets/10467831/25814214/45d0aac2-33e2-11e7-9e62-ec1fecb6d973.png)


![image](https://cloud.githubusercontent.com/assets/10467831/25814257/6a7bb402-33e2-11e7-94f4-b520fe5065cc.png)
