### PR TITLE
Adds an example to the CKEditor showcase for the events

### DIFF
--- a/src/main/webapp/sections/ckEditor/events.xhtml
+++ b/src/main/webapp/sections/ckEditor/events.xhtml
@@ -1,0 +1,43 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:showcase="http://primefaces.org/ui/extensions/showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="CKEditor"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            This widget provides some events you can listen to via a standard
+            <code>&lt;p:ajax&gt;</code> or <code>&lt;pe:javascript&gt;</code>.
+            This page illustrates when each event is fired. For example, try
+            entering some text into the editor or switch to source mode. See the
+            documentation to the right for more information on the individual
+            events. These events should still work after switching to source
+            mode and back to WYSIWYG mode.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+			<ui:include src="/sections/ckEditor/example-events.xhtml" />
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/ckEditor/example-events.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/EditorController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/ckEditor/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="ckEditor"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/src/main/webapp/sections/ckEditor/example-events.xhtml
+++ b/src/main/webapp/sections/ckEditor/example-events.xhtml
@@ -1,0 +1,32 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:pe="http://primefaces.org/ui/extensions">
+
+<!-- EXAMPLE-SOURCE-START -->
+
+<h:outputScript>
+    function showEvent(name) {
+        PF("eventGrowl").renderMessage({summary: "Event triggered", detail: name, severity: "info"});
+    }
+</h:outputScript>
+
+<p:growl id="growl" showDetail="true" widgetVar="eventGrowl" life="1200"/>
+
+<pe:ckEditor id="editor" value="#{editorController.content}">
+    <pe:javascript event="blur" execute="showEvent('blur')" />
+    <pe:javascript event="change" execute="showEvent('change')" />
+    <pe:javascript event="dirty" execute="showEvent('dirty')" />
+    <pe:javascript event="focus" execute="showEvent('focus')" />
+    <pe:javascript event="initialize" execute="showEvent('initialize')" />
+    <pe:javascript event="save" execute="showEvent('save')" />
+    <pe:javascript event="sourceMode" execute="showEvent('sourceMode')" />
+    <pe:javascript event="wysiwygMode" execute="showEvent('wysiwygMode')" />
+</pe:ckEditor>
+
+
+
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/src/main/webapp/sections/ckEditor/useCasesChoice.xhtml
+++ b/src/main/webapp/sections/ckEditor/useCasesChoice.xhtml
@@ -15,6 +15,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('customToolbar')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="fa fa-play"
                     url="#{request.contextPath}/sections/ckEditor/customToolbar.jsf"/>
+        <p:menuitem value="Events"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('events')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="fa fa-play"
+                    url="#{request.contextPath}/sections/ckEditor/events.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
As discussed in primefaces-extensions/primefaces-extensions.github.com#732, this adds an example to the CKEditor showcase that illustrates the available events

This is the first time I added something to the showcase, feel free to tell me if I missed something,

* New example: `primeext-showcase/sections/ckEditor/events.jsf`
* A quick growl message pops up for each triggered event. This makes it easier to test whether the events are working properly, and also lets the user quickly try for themselves when each event is fired.

Looks like this:

![image](https://user-images.githubusercontent.com/2456413/66070790-450bf000-e552-11e9-8257-7ba2e5559e91.png)
